### PR TITLE
Fix device name not found

### DIFF
--- a/manager/cli.py
+++ b/manager/cli.py
@@ -170,7 +170,6 @@ def cli() -> None:
         sys.argv.append('--help')
 
     args = parser.parse_args()
-    print(args)
 
     data = args.execute(args)
 

--- a/manager/cli.py
+++ b/manager/cli.py
@@ -72,7 +72,7 @@ def cli() -> None:
         '--device',
         type=str,
         help='Select the USB-to-UART converter device',
-        nargs=1,
+        nargs='?',
         required=True,
     )
 
@@ -170,12 +170,14 @@ def cli() -> None:
         sys.argv.append('--help')
 
     args = parser.parse_args()
+    print(args)
+
     data = args.execute(args)
 
     # add stop command
     data.append([100, 0, 0, 0])
 
-    device_name = args.device_name
+    device_name = args.device
     is_success = write_data_to_serial(data=data, device_name=device_name)
 
     if is_success:


### PR DESCRIPTION
* Fix the cli not working due to the argparse parsing the device name as a single element list as oppsoed to a single string.
* Alos don't query device_name, use device 