### PR TITLE
Fix VLAN assignment

### DIFF
--- a/manager/cli.py
+++ b/manager/cli.py
@@ -87,7 +87,7 @@ def create_parser() -> argparse.ArgumentParser:
         'vlan',
         help='Configure the ports to be in VLAN groups',
     )
-    vlan_parser_group = vlan_parser.add_mutually_exclusive_group()
+    vlan_parser_group = vlan_parser.add_mutually_exclusive_group(required=True)
     vlan_parser_group.add_argument(
         '-g',
         '--group',
@@ -97,8 +97,11 @@ def create_parser() -> argparse.ArgumentParser:
         choices=[1, 2, 3, 4, 5],
         required=False,
         help='''Define the VLAN member groups using port number,
-        i.e. --group 1 2 --group 3 4 puts makes Group A have
-        ports 1 and 2, and Group B have ports 3 and 4'''
+        i.e. --group 1 2 --group 3 4 makes Group A have
+        ports 1 and 2 and Group B have ports 3 and 4. All unmentioned
+        ports are assigned to default group. If a group has only 1 port,
+        the port gets isolated. In this example, port 5 would
+        not be allowed to communicate with any other port.'''
     )
     vlan_parser_group.add_argument(
         '-r',

--- a/manager/data_manager/vlan.py
+++ b/manager/data_manager/vlan.py
@@ -19,7 +19,7 @@ class VlanConfig:
             'sys_default': 0xFF,
             'data': 0,
             'choice_mapping': {
-                1: 0b00000010,
+                1: 0b00000100,
             }
         },
         2: {
@@ -31,7 +31,7 @@ class VlanConfig:
             'sys_default': 0xFF,
             'data': 0,
             'choice_mapping': {
-                2: 0b00000100,
+                2: 0b00001000,
             }
         },
         3: {
@@ -43,7 +43,7 @@ class VlanConfig:
             'sys_default': 0xFF,
             'data': 0,
             'choice_mapping': {
-                3: 0b00001000,
+                3: 0b00010000,
             }
         },
         4: {

--- a/tests/vlan/test_set_groups.py
+++ b/tests/vlan/test_set_groups.py
@@ -8,7 +8,7 @@ from typing import (
 )
 
 
-class TestSetRxMode:
+class TestSetGroups:
     package: List[str] = ['botblox']
     base_args: List[str] = [
         '--device',
@@ -45,7 +45,7 @@ class TestSetRxMode:
         cli_status_code: int = subprocess.call(command)
         assert cli_status_code > 0, 'The command did not exit with an error code'
 
-    def test_single_rx_port(
+    def test_2x2_groups_1_isolated(
         self,
         parser: ArgumentParser,
     ) -> None:
@@ -61,5 +61,5 @@ class TestSetRxMode:
         data = self._get_data_from_cli_args(parser=parser, args=args)
         self._assert_data_is_correct_type(data=data)
 
-        expected_result = [[23, 16, 6, 6], [23, 17, 72, 0], [23, 18, 72, 255]]
+        expected_result = [[23, 16, 12, 12], [23, 17, 80, 0], [23, 18, 80, 255]]
         assert data == expected_result


### PR DESCRIPTION
There was a bug in port-based VLAN assignment.

PORT 0 had `choice_mapping` `0b00000010`, corresponding to MAC1, but according to the datasheet, PORT 0 is MAC2: `0b00000100`.

![obrazek](https://user-images.githubusercontent.com/182533/114092140-d253a180-98b9-11eb-94ad-aa67658f8595.png)

And so on, ports 1 and 2 were also wrong. This caused weird behavior of ports 0-2 in port-based VLAN, as the commands were configuring different ports.

Fixes #35.

I also fixed the CLI to actually require either `--reset` or `--group`. Before, if you called just `manager vlan`, the program would crash with `TypeError`.