### PR TITLE
[PATCH] Fix args use to match parser config

### DIFF
--- a/botblox_config/cli.py
+++ b/botblox_config/cli.py
@@ -186,7 +186,7 @@ def cli() -> None:
 
     device_name = args.device
     if device_name != "test":
-        writer = switch.get_config_writer(device_name)
+        writer = args.device
         is_success = writer.write(data)
 
         if is_success:


### PR DESCRIPTION
Parser argument `type=switch.get_config_writer` already turn the device parameter into a config writer.